### PR TITLE
98 Add travis ci build status to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # NotaryNow
+[![Build Status](https://travis-ci.org/notary-now/backend_notary_now.svg?branch=master)](https://travis-ci.org/notary-now/backend_notary_now)
 
 ## Backend Service
 


### PR DESCRIPTION
### Fixes #98

## Type of change
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes
- Add deployment status to read me from travis
